### PR TITLE
Sort lsvpc data structures internally

### DIFF
--- a/dataModel.go
+++ b/dataModel.go
@@ -12,16 +12,27 @@ type RegionData struct {
 	VPCs map[string]VPC
 }
 
-type VPC struct {
+type VPCData struct {
 	Id            *string
 	IsDefault     bool
 	CidrBlock     *string
 	IPv6CidrBlock *string
 	Name          *string
 	RawVPC        *ec2.Vpc
-	Gateways      []string
-	Subnets       map[string]Subnet
-	Peers         map[string]VPCPeer
+}
+
+type VPCSorted struct {
+	VPCData
+	Gateways []string
+	Subnets  []Subnet
+	Peers    []VPCPeer
+}
+
+type VPC struct {
+	VPCData
+	Gateways []string
+	Subnets  map[string]Subnet
+	Peers    map[string]VPCPeer
 }
 
 type Subnet struct {

--- a/dataModel.go
+++ b/dataModel.go
@@ -24,7 +24,7 @@ type VPCData struct {
 type VPCSorted struct {
 	VPCData
 	Gateways []string
-	Subnets  []Subnet
+	Subnets  []SubnetSorted
 	Peers    []VPCPeer
 }
 
@@ -35,7 +35,7 @@ type VPC struct {
 	Peers    map[string]VPCPeer
 }
 
-type Subnet struct {
+type SubnetData struct {
 	Id                 *string
 	CidrBlock          *string
 	AvailabilityZone   *string
@@ -44,6 +44,20 @@ type Subnet struct {
 	Name               *string
 	RawSubnet          *ec2.Subnet
 	RouteTable         *RouteTable
+}
+
+type SubnetSorted struct {
+	SubnetData
+	Instances          []Instance
+	NatGateways        []NatGateway
+	TGWs               []TGWAttachment
+	ENIs               []NetworkInterface
+	InterfaceEndpoints []InterfaceEndpoint
+	GatewayEndpoints   []GatewayEndpoint
+}
+
+type Subnet struct {
+	SubnetData
 	Instances          map[string]Instance
 	NatGateways        map[string]NatGateway
 	TGWs               map[string]TGWAttachment

--- a/dataModel.go
+++ b/dataModel.go
@@ -48,7 +48,7 @@ type SubnetData struct {
 
 type SubnetSorted struct {
 	SubnetData
-	Instances          []Instance
+	Instances          []InstanceSorted
 	NatGateways        []NatGateway
 	TGWs               []TGWAttachment
 	ENIs               []NetworkInterface
@@ -66,7 +66,7 @@ type Subnet struct {
 	GatewayEndpoints   map[string]GatewayEndpoint
 }
 
-type Instance struct {
+type InstanceData struct {
 	Id             *string
 	Type           *string
 	SubnetId       *string
@@ -77,9 +77,19 @@ type Instance struct {
 	Name           *string
 	InstanceStatus *string
 	SystemStatus   *string
-	Volumes        map[string]Volume
-	Interfaces     map[string]NetworkInterface
 	RawEc2         *ec2.Instance
+}
+
+type InstanceSorted struct {
+	InstanceData
+	Volumes    []Volume
+	Interfaces []NetworkInterface
+}
+
+type Instance struct {
+	InstanceData
+	Volumes    map[string]Volume
+	Interfaces map[string]NetworkInterface
 }
 
 type NetworkInterface struct {

--- a/display.go
+++ b/display.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -85,7 +84,8 @@ func printSortedVPCs(vpcs []VPCSorted) {
 	}
 }
 
-func printVPCs(vpcs map[string]VPC) {
+func printVPCs(in map[string]VPC) {
+	vpcs := sortVPCs(in)
 	color := colorPalette{}
 
 	if !Config.noColor {
@@ -100,14 +100,7 @@ func printVPCs(vpcs map[string]VPC) {
 	}
 
 	//sort the keys
-	vpcKeys := []string{}
-	for k := range vpcs {
-		vpcKeys = append(vpcKeys, k)
-	}
-	sort.Strings(vpcKeys)
-	for _, vpcId := range vpcKeys {
-		vpc := vpcs[vpcId]
-
+	for _, vpc := range vpcs {
 		// Print VPC
 		fmt.Printf(
 			"%v%v%v%v ",
@@ -144,13 +137,7 @@ func printVPCs(vpcs map[string]VPC) {
 
 		// Print Peers
 		peersExist := false
-		peerKeys := []string{}
-		for k := range vpc.Peers {
-			peerKeys = append(peerKeys, k)
-		}
-		sort.Strings(peerKeys)
-		for _, peerId := range peerKeys {
-			peer := vpc.Peers[peerId]
+		for _, peer := range vpc.Peers {
 			direction := "peer-->"
 			vpcOperand := aws.StringValue(peer.Accepter)
 			if aws.StringValue(peer.Accepter) == aws.StringValue(vpc.Id) {
@@ -176,14 +163,7 @@ func printVPCs(vpcs map[string]VPC) {
 		}
 
 		// Print Subnets
-		subnetKeys := []string{}
-		for k := range vpc.Subnets {
-			subnetKeys = append(subnetKeys, k)
-		}
-		sort.Strings(subnetKeys)
-		for _, subnetId := range subnetKeys {
-
-			subnet := vpc.Subnets[subnetId]
+		for _, subnet := range vpc.Subnets {
 
 			// Print Subnet Info
 			public := "Private"
@@ -206,13 +186,7 @@ func printVPCs(vpcs map[string]VPC) {
 			)
 
 			//Print Endpoints
-			interfaceEndpointKeys := []string{}
-			for k := range subnet.InterfaceEndpoints {
-				interfaceEndpointKeys = append(interfaceEndpointKeys, k)
-			}
-			sort.Strings(interfaceEndpointKeys)
-			for _, interfaceEndpointId := range interfaceEndpointKeys {
-				interfaceEndpoint := subnet.InterfaceEndpoints[interfaceEndpointId]
+			for _, interfaceEndpoint := range subnet.InterfaceEndpoints {
 				fmt.Printf(
 					"%s%v%v%v%v interface--> %v\n",
 					indent(8),
@@ -224,13 +198,7 @@ func printVPCs(vpcs map[string]VPC) {
 				)
 			}
 
-			gatewayKeys := []string{}
-			for k := range subnet.GatewayEndpoints {
-				gatewayKeys = append(gatewayKeys, k)
-			}
-			sort.Strings(gatewayKeys)
-			for _, gatewayEndpointId := range gatewayKeys {
-				gatewayEndpoint := subnet.GatewayEndpoints[gatewayEndpointId]
+			for _, gatewayEndpoint := range subnet.GatewayEndpoints {
 				fmt.Printf(
 					"%s%v%v%v%v gateway--> %v\n",
 					indent(8),
@@ -243,13 +211,7 @@ func printVPCs(vpcs map[string]VPC) {
 			}
 
 			// Print Interfaces
-			interfaceKeys := []string{}
-			for k := range subnet.ENIs {
-				interfaceKeys = append(interfaceKeys, k)
-			}
-			sort.Strings(interfaceKeys)
-			for _, interfaceId := range interfaceKeys {
-				iface := subnet.ENIs[interfaceId]
+			for _, iface := range subnet.ENIs {
 				fmt.Printf(
 					"%s%v%v%v%v %v %v %v %v %v : %v\n",
 					indent(8),
@@ -266,14 +228,7 @@ func printVPCs(vpcs map[string]VPC) {
 				)
 			}
 			// Print EC2 Instances
-			instanceKeys := []string{}
-			for k := range subnet.Instances {
-				instanceKeys = append(instanceKeys, k)
-			}
-			sort.Strings(instanceKeys)
-			for _, instanceId := range instanceKeys {
-				instance := subnet.Instances[instanceId]
-
+			for _, instance := range subnet.Instances {
 				// Its too clunky to directly report SystemStatus and InstanceStatus, lets do it like the console does
 				status := 0
 				if aws.StringValue(instance.SystemStatus) == "ok" {
@@ -299,13 +254,7 @@ func printVPCs(vpcs map[string]VPC) {
 				)
 
 				// Print Instance Interfaces
-				instanceInterfaceKeys := []string{}
-				for k := range instance.Interfaces {
-					instanceInterfaceKeys = append(instanceInterfaceKeys, k)
-				}
-				sort.Strings(instanceInterfaceKeys)
-				for _, interfaceId := range instanceInterfaceKeys {
-					iface := instance.Interfaces[interfaceId]
+				for _, iface := range instance.Interfaces {
 					fmt.Printf(
 						"%s%v%v  %v  %v  %v\n",
 						indent(12),
@@ -332,13 +281,7 @@ func printVPCs(vpcs map[string]VPC) {
 			}
 
 			//Print Nat Gateways
-			natGatewayKeys := []string{}
-			for k := range subnet.NatGateways {
-				natGatewayKeys = append(natGatewayKeys, k)
-			}
-			sort.Strings(natGatewayKeys)
-			for _, natGatewayId := range natGatewayKeys {
-				natGateway := subnet.NatGateways[natGatewayId]
+			for _, natGateway := range subnet.NatGateways {
 				fmt.Printf(
 					"%s%v%v%v%v  %v  %v  %v  %v\n",
 					indent(8),
@@ -354,13 +297,7 @@ func printVPCs(vpcs map[string]VPC) {
 			}
 
 			//Print Transit Gateway Attachments
-			tgwKeys := []string{}
-			for k := range subnet.TGWs {
-				tgwKeys = append(tgwKeys, k)
-			}
-			sort.Strings(tgwKeys)
-			for _, tgwId := range tgwKeys {
-				tgw := subnet.TGWs[tgwId]
+			for _, tgw := range subnet.TGWs {
 				fmt.Printf(
 					"%s%v%v%v%v ---> %v%v%v\n",
 					indent(8),

--- a/display.go
+++ b/display.go
@@ -52,6 +52,15 @@ func formatName(name *string) string {
 	return fmt.Sprintf(" [%s]", string(runes))
 }
 
+func printSortedVPCs(vpcs []VPCSorted) {
+	for _, vpc := range vpcs {
+		fmt.Printf("%v [%v]\n", aws.StringValue(vpc.Id), aws.StringValue(vpc.Name))
+		for _, subnet := range vpc.Subnets {
+			fmt.Printf("    %v\n", aws.StringValue(subnet.Id))
+		}
+	}
+}
+
 func printVPCs(vpcs map[string]VPC) {
 	color := colorPalette{}
 

--- a/display.go
+++ b/display.go
@@ -57,6 +57,24 @@ func printSortedVPCs(vpcs []VPCSorted) {
 		fmt.Printf("%v [%v]\n", aws.StringValue(vpc.Id), aws.StringValue(vpc.Name))
 		for _, subnet := range vpc.Subnets {
 			fmt.Printf("    %v\n", aws.StringValue(subnet.Id))
+			for _, nat := range subnet.NatGateways {
+				fmt.Printf("      %v\n", aws.StringValue(nat.Id))
+			}
+			for _, tgw := range subnet.NatGateways {
+				fmt.Printf("      %v\n", aws.StringValue(tgw.Id))
+			}
+			for _, eni := range subnet.ENIs {
+				fmt.Printf("      %v\n", aws.StringValue(eni.Id))
+			}
+			for _, interfaceEndpoint := range subnet.InterfaceEndpoints {
+				fmt.Printf("      %v\n", aws.StringValue(interfaceEndpoint.Id))
+			}
+			for _, gatewayEndpoint := range subnet.GatewayEndpoints {
+				fmt.Printf("      %v\n", aws.StringValue(gatewayEndpoint.Id))
+			}
+			for _, instance := range subnet.Instances {
+				fmt.Printf("      %v\n", aws.StringValue(instance.Id))
+			}
 		}
 	}
 }

--- a/display.go
+++ b/display.go
@@ -74,6 +74,12 @@ func printSortedVPCs(vpcs []VPCSorted) {
 			}
 			for _, instance := range subnet.Instances {
 				fmt.Printf("      %v\n", aws.StringValue(instance.Id))
+				for _, volume := range instance.Volumes {
+					fmt.Printf("        %v\n", aws.StringValue(volume.Id))
+				}
+				for _, eni := range instance.Interfaces {
+					fmt.Printf("        %v\n", aws.StringValue(eni.Id))
+				}
 			}
 		}
 	}

--- a/display.go
+++ b/display.go
@@ -51,39 +51,6 @@ func formatName(name *string) string {
 	return fmt.Sprintf(" [%s]", string(runes))
 }
 
-func printSortedVPCs(vpcs []VPCSorted) {
-	for _, vpc := range vpcs {
-		fmt.Printf("%v [%v]\n", aws.StringValue(vpc.Id), aws.StringValue(vpc.Name))
-		for _, subnet := range vpc.Subnets {
-			fmt.Printf("    %v\n", aws.StringValue(subnet.Id))
-			for _, nat := range subnet.NatGateways {
-				fmt.Printf("      %v\n", aws.StringValue(nat.Id))
-			}
-			for _, tgw := range subnet.NatGateways {
-				fmt.Printf("      %v\n", aws.StringValue(tgw.Id))
-			}
-			for _, eni := range subnet.ENIs {
-				fmt.Printf("      %v\n", aws.StringValue(eni.Id))
-			}
-			for _, interfaceEndpoint := range subnet.InterfaceEndpoints {
-				fmt.Printf("      %v\n", aws.StringValue(interfaceEndpoint.Id))
-			}
-			for _, gatewayEndpoint := range subnet.GatewayEndpoints {
-				fmt.Printf("      %v\n", aws.StringValue(gatewayEndpoint.Id))
-			}
-			for _, instance := range subnet.Instances {
-				fmt.Printf("      %v\n", aws.StringValue(instance.Id))
-				for _, volume := range instance.Volumes {
-					fmt.Printf("        %v\n", aws.StringValue(volume.Id))
-				}
-				for _, eni := range instance.Interfaces {
-					fmt.Printf("        %v\n", aws.StringValue(eni.Id))
-				}
-			}
-		}
-	}
-}
-
 func printVPCs(in map[string]VPC) {
 	vpcs := sortVPCs(in)
 	color := colorPalette{}

--- a/main.go
+++ b/main.go
@@ -135,8 +135,6 @@ func doDefaultRegion() {
 	if err != nil {
 		panic(fmt.Sprintf("populateVPC failed: %v", err.Error()))
 	}
-	//vpcsSorted := sortVPCs(vpcs)
-	//printSortedVPCs(vpcsSorted)
 	printVPCs(vpcs)
 }
 

--- a/main.go
+++ b/main.go
@@ -135,7 +135,8 @@ func doDefaultRegion() {
 	if err != nil {
 		panic(fmt.Sprintf("populateVPC failed: %v", err.Error()))
 	}
-
+	//vpcsSorted := sortVPCs(vpcs)
+	//printSortedVPCs(vpcsSorted)
 	printVPCs(vpcs)
 }
 

--- a/mappings.go
+++ b/mappings.go
@@ -33,14 +33,16 @@ func mapVpcs(vpcs map[string]VPC, vpcData []*ec2.Vpc) {
 		}
 
 		vpcs[aws.StringValue(v.VpcId)] = VPC{
-			Id:            v.VpcId,
-			IsDefault:     aws.BoolValue(v.IsDefault),
-			CidrBlock:     v.CidrBlock,
-			IPv6CidrBlock: v6cidr,
-			Name:          getNameTag(v.Tags),
-			RawVPC:        v,
-			Subnets:       make(map[string]Subnet),
-			Peers:         make(map[string]VPCPeer),
+			VPCData: VPCData{
+				Id:            v.VpcId,
+				IsDefault:     aws.BoolValue(v.IsDefault),
+				CidrBlock:     v.CidrBlock,
+				IPv6CidrBlock: v6cidr,
+				Name:          getNameTag(v.Tags),
+				RawVPC:        v,
+			},
+			Subnets: make(map[string]Subnet),
+			Peers:   make(map[string]VPCPeer),
 		}
 	}
 }

--- a/mappings.go
+++ b/mappings.go
@@ -84,17 +84,19 @@ func mapInstances(vpcs map[string]VPC, reservations []*ec2.Reservation) {
 				if vpcId != "" && subnetId != "" && instanceId != "" {
 
 					vpcs[vpcId].Subnets[subnetId].Instances[instanceId] = Instance{
-						Id:         instance.InstanceId,
-						Type:       instance.InstanceType,
-						SubnetId:   instance.SubnetId,
-						VpcId:      instance.VpcId,
-						State:      instance.State.Name,
-						PublicIP:   instance.PublicIpAddress,
-						PrivateIP:  instance.PrivateIpAddress,
+						InstanceData: InstanceData{
+							Id:        instance.InstanceId,
+							Type:      instance.InstanceType,
+							SubnetId:  instance.SubnetId,
+							VpcId:     instance.VpcId,
+							State:     instance.State.Name,
+							PublicIP:  instance.PublicIpAddress,
+							PrivateIP: instance.PrivateIpAddress,
+							RawEc2:    instance,
+							Name:      getNameTag(instance.Tags),
+						},
 						Volumes:    make(map[string]Volume),
 						Interfaces: make(map[string]NetworkInterface),
-						RawEc2:     instance,
-						Name:       getNameTag(instance.Tags),
 					}
 				}
 			}

--- a/mappings.go
+++ b/mappings.go
@@ -52,13 +52,15 @@ func mapSubnets(vpcs map[string]VPC, subnets []*ec2.Subnet) {
 		isPublic := aws.BoolValue(v.MapCustomerOwnedIpOnLaunch) || aws.BoolValue(v.MapPublicIpOnLaunch)
 
 		vpcs[*v.VpcId].Subnets[*v.SubnetId] = Subnet{
-			Id:                 v.SubnetId,
-			CidrBlock:          v.CidrBlock,
-			AvailabilityZone:   v.AvailabilityZone,
-			AvailabilityZoneId: v.AvailabilityZoneId,
-			Name:               getNameTag(v.Tags),
-			RawSubnet:          v,
-			Public:             isPublic,
+			SubnetData: SubnetData{
+				Id:                 v.SubnetId,
+				CidrBlock:          v.CidrBlock,
+				AvailabilityZone:   v.AvailabilityZone,
+				AvailabilityZoneId: v.AvailabilityZoneId,
+				Name:               getNameTag(v.Tags),
+				RawSubnet:          v,
+				Public:             isPublic,
+			},
 			Instances:          make(map[string]Instance),
 			NatGateways:        make(map[string]NatGateway),
 			TGWs:               make(map[string]TGWAttachment),

--- a/sort.go
+++ b/sort.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"sort"
+)
+
+func sortVPCs(vpcs map[string]VPC) []VPCSorted {
+
+	vpcKeys := []string{}
+	for k := range vpcs {
+		vpcKeys = append(vpcKeys, k)
+	}
+
+	sort.Strings(vpcKeys)
+
+	vpcsSorted := []VPCSorted{}
+	for _, vpcId := range vpcKeys {
+		vpcsSorted = append(vpcsSorted, sortVPC(vpcs[vpcId]))
+	}
+	return vpcsSorted
+}
+
+func sortVPC(vpc VPC) VPCSorted {
+
+	//sort Gateways
+	gatewaysSorted := vpc.Gateways
+	sort.Strings(gatewaysSorted)
+
+	//sort subnets
+	subnetKeys := []string{}
+	for k := range vpc.Subnets {
+		subnetKeys = append(subnetKeys, k)
+	}
+	sort.Strings(subnetKeys)
+
+	subnetsSorted := []Subnet{}
+	for _, subnetId := range subnetKeys {
+		subnetsSorted = append(subnetsSorted, vpc.Subnets[subnetId])
+	}
+
+	//sort peers
+	peerKeys := []string{}
+	for k := range vpc.Peers {
+		peerKeys = append(peerKeys, k)
+	}
+	sort.Strings(peerKeys)
+	peersSorted := []VPCPeer{}
+	for _, peerId := range peerKeys {
+		peersSorted = append(peersSorted, vpc.Peers[peerId])
+	}
+
+	return VPCSorted{
+		VPCData:  vpc.VPCData,
+		Gateways: gatewaysSorted,
+		Subnets:  subnetsSorted,
+		Peers:    peersSorted,
+	}
+}

--- a/sort.go
+++ b/sort.go
@@ -33,9 +33,9 @@ func sortVPC(vpc VPC) VPCSorted {
 	}
 	sort.Strings(subnetKeys)
 
-	subnetsSorted := []Subnet{}
+	subnetsSorted := []SubnetSorted{}
 	for _, subnetId := range subnetKeys {
-		subnetsSorted = append(subnetsSorted, vpc.Subnets[subnetId])
+		subnetsSorted = append(subnetsSorted, sortSubnet(vpc.Subnets[subnetId]))
 	}
 
 	//sort peers
@@ -54,5 +54,83 @@ func sortVPC(vpc VPC) VPCSorted {
 		Gateways: gatewaysSorted,
 		Subnets:  subnetsSorted,
 		Peers:    peersSorted,
+	}
+}
+
+func sortSubnet(subnet Subnet) SubnetSorted {
+	//sort Instances
+	instanceKeys := []string{}
+	for k := range subnet.Instances {
+		instanceKeys = append(instanceKeys, k)
+	}
+	sort.Strings(instanceKeys)
+	instancesSorted := []Instance{}
+	for _, instanceId := range instanceKeys {
+		instancesSorted = append(instancesSorted, subnet.Instances[instanceId])
+	}
+
+	//sort NatGateways
+	natGatewayKeys := []string{}
+	for k := range subnet.NatGateways {
+		natGatewayKeys = append(natGatewayKeys, k)
+	}
+	sort.Strings(natGatewayKeys)
+	natGatewaysSorted := []NatGateway{}
+	for _, natGatewayId := range natGatewayKeys {
+		natGatewaysSorted = append(natGatewaysSorted, subnet.NatGateways[natGatewayId])
+	}
+
+	//sort TGWAttachments
+	transitGatewayKeys := []string{}
+	for k := range subnet.TGWs {
+		transitGatewayKeys = append(transitGatewayKeys, k)
+	}
+	sort.Strings(transitGatewayKeys)
+	transitGatewaysSorted := []TGWAttachment{}
+	for _, transitGatewayId := range transitGatewayKeys {
+		transitGatewaysSorted = append(transitGatewaysSorted, subnet.TGWs[transitGatewayId])
+	}
+
+	//sort ENIs
+	networkInterfaceKeys := []string{}
+	for k := range subnet.ENIs {
+		networkInterfaceKeys = append(networkInterfaceKeys, k)
+	}
+	sort.Strings(networkInterfaceKeys)
+	networkInterfacesSorted := []NetworkInterface{}
+	for _, networkInterfaceId := range networkInterfaceKeys {
+		networkInterfacesSorted = append(networkInterfacesSorted, subnet.ENIs[networkInterfaceId])
+	}
+
+	//sort InterfaceEndpoints
+	interfaceEndpointKeys := []string{}
+	for k := range subnet.InterfaceEndpoints {
+		interfaceEndpointKeys = append(interfaceEndpointKeys, k)
+	}
+	sort.Strings(interfaceEndpointKeys)
+	interfaceEndpointsSorted := []InterfaceEndpoint{}
+	for _, interfaceEndpointId := range interfaceEndpointKeys {
+		interfaceEndpointsSorted = append(interfaceEndpointsSorted, subnet.InterfaceEndpoints[interfaceEndpointId])
+	}
+
+	//sort GatewayEndpoints
+	gatewayEndpointKeys := []string{}
+	for k := range subnet.GatewayEndpoints {
+		gatewayEndpointKeys = append(gatewayEndpointKeys, k)
+	}
+	sort.Strings(gatewayEndpointKeys)
+	gatewayEndpointsSorted := []GatewayEndpoint{}
+	for _, gatewayEndpointId := range gatewayEndpointKeys {
+		gatewayEndpointsSorted = append(gatewayEndpointsSorted, subnet.GatewayEndpoints[gatewayEndpointId])
+	}
+
+	return SubnetSorted{
+		SubnetData:         subnet.SubnetData,
+		Instances:          instancesSorted,
+		NatGateways:        natGatewaysSorted,
+		TGWs:               transitGatewaysSorted,
+		ENIs:               networkInterfacesSorted,
+		InterfaceEndpoints: interfaceEndpointsSorted,
+		GatewayEndpoints:   gatewayEndpointsSorted,
 	}
 }

--- a/sort.go
+++ b/sort.go
@@ -64,9 +64,9 @@ func sortSubnet(subnet Subnet) SubnetSorted {
 		instanceKeys = append(instanceKeys, k)
 	}
 	sort.Strings(instanceKeys)
-	instancesSorted := []Instance{}
+	instancesSorted := []InstanceSorted{}
 	for _, instanceId := range instanceKeys {
-		instancesSorted = append(instancesSorted, subnet.Instances[instanceId])
+		instancesSorted = append(instancesSorted, sortInstance(subnet.Instances[instanceId]))
 	}
 
 	//sort NatGateways
@@ -133,4 +133,36 @@ func sortSubnet(subnet Subnet) SubnetSorted {
 		InterfaceEndpoints: interfaceEndpointsSorted,
 		GatewayEndpoints:   gatewayEndpointsSorted,
 	}
+}
+
+func sortInstance(instance Instance) InstanceSorted {
+
+	// sort volumes
+	volumeKeys := []string{}
+	for k := range instance.Volumes {
+		volumeKeys = append(volumeKeys, k)
+	}
+	sort.Strings(volumeKeys)
+	volumesSorted := []Volume{}
+	for _, volumeId := range volumeKeys {
+		volumesSorted = append(volumesSorted, instance.Volumes[volumeId])
+	}
+
+	// sort network interfaces
+	interfaceKeys := []string{}
+	for k := range instance.Interfaces {
+		interfaceKeys = append(interfaceKeys, k)
+	}
+	sort.Strings(interfaceKeys)
+	interfacesSorted := []NetworkInterface{}
+	for _, interfaceId := range interfaceKeys {
+		interfacesSorted = append(interfacesSorted, instance.Interfaces[interfaceId])
+	}
+
+	return InstanceSorted{
+		InstanceData: instance.InstanceData,
+		Volumes:      volumesSorted,
+		Interfaces:   interfacesSorted,
+	}
+
 }

--- a/sorting.go
+++ b/sorting.go
@@ -1,8 +1,6 @@
 package main
 
-import (
-	"sort"
-)
+import "sort"
 
 func sortVPCs(vpcs map[string]VPC) []VPCSorted {
 


### PR DESCRIPTION
One of the bits of technical debt that accumulated is that lsvpc plays fast and loose with map data structures in order to perform complex stitching of data mapped in from multiple api calls, however the problem with maps is that they are not trivially sortable, and we are left with a core data model that is not inherently canonical.

The first step towards producing a canonical data output of lsvpc is by being able to sort the constituent parts of the lsvpc data structure. This will be carried out by using a new struct definition heirarchy that uses lists instead of maps to use for final presentation of data. I dont want to abandon the maps-on-maps implementation because it is so handy for doing complex data stitching, so an intermediate stage where the data is sorted and presented as lists-of-lists will be implemented

This sorting will also make printing logic immensely easier, and will also prepare the data for json marshalling.