### PR TITLE
make truncation a commandline flag

### DIFF
--- a/display.go
+++ b/display.go
@@ -8,7 +8,6 @@ import (
 )
 
 const nameTruncate = 20 //max size a Name tag can be before its truncated with a "..." at the end
-const doTruncate = false
 
 func indent(num int) string {
 	sb := strings.Builder{}
@@ -43,7 +42,7 @@ func formatName(name string) string {
 	}
 	//Names can be up to 255 utf8 runes, we should truncate it
 	runes := []rune(name)
-	if doTruncate {
+	if Config.Truncate {
 		if len(runes) > nameTruncate {
 			runes = runes[:(nameTruncate - 1 - 3)]
 			runes = append(runes, []rune("...")...)

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ type lsvpcConfig struct {
 	Color          bool
 	jsonOutput     bool
 	Verbose        bool
+	Truncate       bool
 }
 
 var Config lsvpcConfig
@@ -163,6 +164,7 @@ func init() {
 	flag.StringVar(&Config.regionOverride, "r", "", "Specify region (default: profile default region) (abbrev.)")
 	flag.BoolVar(&Config.jsonOutput, "j", false, "Output json instead of the typical textual output")
 	flag.BoolVar(&Config.Verbose, "v", false, "output verbose information about assets in vpc")
+	flag.BoolVar(&Config.Verbose, "t", false, "truncate nametags")
 }
 
 func stdoutIsPipe() bool {


### PR DESCRIPTION
Implement truncate, which just toggles name tag truncation to 20 chars.

closes #1 