### PR TITLE
fix linefeed bug with lsvpc -nospace

### DIFF
--- a/display.go
+++ b/display.go
@@ -116,7 +116,7 @@ func printVPCs(vpcs []VPCSorted) {
 			)
 		}
 
-		lineFeed()
+		fmt.Printf("\n")
 
 		// Print Peers
 		peersExist := false


### PR DESCRIPTION
when you call lsvpc with -nospace to eliminate extra linefeeds, lsvpc fails to linefeed after the vpc entry, with the next subnet entry showing up.