### PR TITLE
Add security groups to lsvpc

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,3 +58,4 @@ linters:
 run:
   issues-exit-code: 1
   concurrency: 2
+  timeout: 5m

--- a/dataModel.go
+++ b/dataModel.go
@@ -86,8 +86,8 @@ type InstanceData struct {
 
 type InstanceSorted struct {
 	InstanceData
-	Volumes    []*Volume           `json:"volumes,omitempty"`
-	Interfaces []*NetworkInterface `json:"interfaces,omitempty"`
+	Volumes    []*Volume                 `json:"volumes,omitempty"`
+	Interfaces []*NetworkInterfaceSorted `json:"interfaces,omitempty"`
 }
 
 type Instance struct {
@@ -97,7 +97,7 @@ type Instance struct {
 	InstanceData
 }
 
-type NetworkInterface struct {
+type NetworkInterfaceData struct {
 	RawNetworkInterface *ec2.NetworkInterface `json:"-"`
 	ID                  string                `json:"id"`
 	PrivateIP           string                `json:"privateIp"`
@@ -110,6 +110,43 @@ type NetworkInterface struct {
 	SubnetID            string                `json:"subnetId"` // we're just accounting for this for display purposes
 }
 
+type NetworkInterface struct {
+	NetworkInterfaceData
+	Groups map[string]*SecurityGroup `json:"groups"`
+}
+
+type NetworkInterfaceSorted struct {
+	NetworkInterfaceData
+	Groups []*SecurityGroup `json:"groups"`
+}
+
+type SecurityGroup struct {
+	Description         string               `json:"description"`
+	GroupID             string               `json:"groupId"`
+	GroupName           string               `json:"groupName"`
+	IpPermissions       []*SecurityGroupRule `json:"ipPermissions"`
+	IpPermissionsEgress []*SecurityGroupRule `json:"ipPermissionsEgress"`
+	TagName             string               `json:"tagName"`
+	RawSecurityGroup    *ec2.SecurityGroup   `json:"-"`
+}
+
+type SecurityGroupRule struct {
+	FromPort   int64        `json:"fromPort"`
+	ToPort     int64        `json:"toPort"`
+	IpProtocol string       `json:"ipProtocol"`
+	IpRanges   []*IpRange   `json:"ipRanges"`
+	Ipv6Ranges []*Ipv6Range `json:"ipv6Ranges"`
+}
+
+type IpRange struct {
+	CidrIP      string `json:"cidrIp"`
+	Description string `json:"description"`
+}
+
+type Ipv6Range struct {
+	CidrIPV6    string `json:"cidrIpv6"`
+	Description string `json:"description"`
+}
 type Volume struct {
 	RawVolume  *ec2.Volume `json:"-"`
 	ID         string      `json:"id"`
@@ -118,7 +155,7 @@ type Volume struct {
 	Name       string      `json:"name"`
 	Size       int64       `json:"size"`
 }
-type NatGateway struct {
+type NatGatewayData struct {
 	RawNatGateway *ec2.NatGateway `json:"-"`
 	ID            string          `json:"id"`
 	PrivateIP     string          `json:"privateIP"`
@@ -126,6 +163,15 @@ type NatGateway struct {
 	State         string          `json:"state"`
 	Type          string          `json:"type"`
 	Name          string          `json:"name"`
+}
+type NatGateway struct {
+	NatGatewayData
+	Interfaces map[string]*NetworkInterface `json:"interfaces"`
+}
+
+type NatGatewaySorted struct {
+	NatGatewayData
+	Interfaces []*NetworkInterfaceSorted `json:"interfaces"`
 }
 
 type RouteTable struct {
@@ -163,7 +209,7 @@ type InterfaceEndpoint struct {
 
 type InterfaceEndpointSorted struct {
 	InterfaceEndpointData
-	Interfaces []*NetworkInterface
+	Interfaces []*NetworkInterfaceSorted
 }
 
 type GatewayEndpoint struct {
@@ -188,6 +234,7 @@ type RecievedData struct {
 	TransitGateways    []*ec2.TransitGatewayVpcAttachment
 	PeeringConnections []*ec2.VpcPeeringConnection
 	NetworkInterfaces  []*ec2.NetworkInterface
+	SecurityGroups     []*ec2.SecurityGroup
 	VPCEndpoints       []*ec2.VpcEndpoint
 	Volumes            []*ec2.Volume
 	wg                 sync.WaitGroup

--- a/dataModel.go
+++ b/dataModel.go
@@ -111,8 +111,8 @@ type NetworkInterfaceData struct {
 }
 
 type NetworkInterface struct {
-	NetworkInterfaceData
 	Groups map[string]*SecurityGroup `json:"groups"`
+	NetworkInterfaceData
 }
 
 type NetworkInterfaceSorted struct {
@@ -121,29 +121,29 @@ type NetworkInterfaceSorted struct {
 }
 
 type SecurityGroup struct {
+	RawSecurityGroup    *ec2.SecurityGroup   `json:"-"`
 	Description         string               `json:"description"`
 	GroupID             string               `json:"groupId"`
 	GroupName           string               `json:"groupName"`
-	IpPermissions       []*SecurityGroupRule `json:"ipPermissions"`
-	IpPermissionsEgress []*SecurityGroupRule `json:"ipPermissionsEgress"`
 	TagName             string               `json:"tagName"`
-	RawSecurityGroup    *ec2.SecurityGroup   `json:"-"`
+	IPPermissions       []*SecurityGroupRule `json:"ipPermissions"`
+	IPPermissionsEgress []*SecurityGroupRule `json:"ipPermissionsEgress"`
 }
 
 type SecurityGroupRule struct {
+	IPProtocol string       `json:"ipProtocol"`
+	IPRanges   []*IPRange   `json:"ipRanges"`
+	IPv6Ranges []*IPv6Range `json:"ipv6Ranges"`
 	FromPort   int64        `json:"fromPort"`
 	ToPort     int64        `json:"toPort"`
-	IpProtocol string       `json:"ipProtocol"`
-	IpRanges   []*IpRange   `json:"ipRanges"`
-	Ipv6Ranges []*Ipv6Range `json:"ipv6Ranges"`
 }
 
-type IpRange struct {
+type IPRange struct {
 	CidrIP      string `json:"cidrIp"`
 	Description string `json:"description"`
 }
 
-type Ipv6Range struct {
+type IPv6Range struct {
 	CidrIPV6    string `json:"cidrIpv6"`
 	Description string `json:"description"`
 }
@@ -165,8 +165,8 @@ type NatGatewayData struct {
 	Name          string          `json:"name"`
 }
 type NatGateway struct {
-	NatGatewayData
 	Interfaces map[string]*NetworkInterface `json:"interfaces"`
+	NatGatewayData
 }
 
 type NatGatewaySorted struct {

--- a/display.go
+++ b/display.go
@@ -199,9 +199,10 @@ func printInterfaceEndpoint(interfaceEndpoint *InterfaceEndpointSorted, subnet *
 				iface.DNS,
 			)
 		}
+
 		if Config.Verbose {
 			for _, group := range iface.Groups {
-				printSecurityGroup(group, 16)
+				printSecurityGroup(group, 16) //nolint:gomnd // not a magic number, spaces to indent by
 			}
 		}
 	}
@@ -247,7 +248,7 @@ func printNetworkInterface(iface *NetworkInterface) {
 
 	if Config.Verbose {
 		for _, group := range iface.Groups {
-			printSecurityGroup(group, 12)
+			printSecurityGroup(group, 12) //nolint:gomnd // not a magic number, spaces to indent by
 		}
 	}
 }
@@ -307,9 +308,10 @@ func printInstanceInterface(iface *NetworkInterfaceSorted) {
 		iface.PrivateIP,
 		iface.DNS,
 	)
+
 	if Config.Verbose {
 		for _, group := range iface.Groups {
-			printSecurityGroup(group, 16)
+			printSecurityGroup(group, 16) //nolint:gomnd // not a magic number, spaces to indent by
 		}
 	}
 }
@@ -348,7 +350,7 @@ func printNatGateway(natGateway *NatGateway) {
 	if Config.Verbose {
 		for _, iface := range natGateway.Interfaces {
 			for _, group := range iface.Groups {
-				printSecurityGroup(group, 12)
+				printSecurityGroup(group, 12) //nolint:gomnd // not a magic number, spaces to indent by
 			}
 		}
 	}
@@ -372,7 +374,7 @@ func printRules(rules []*SecurityGroupRule, ind int, ingress bool) {
 	for _, rule := range rules {
 		portRange := fmt.Sprintf("%v-%v", rule.FromPort, rule.ToPort)
 		direction := "inbound"
-		proto := rule.IpProtocol
+		proto := rule.IPProtocol
 
 		if !ingress {
 			direction = "outbound"
@@ -382,12 +384,12 @@ func printRules(rules []*SecurityGroupRule, ind int, ingress bool) {
 			portRange = fmt.Sprintf("%v", rule.FromPort)
 		}
 
-		if rule.IpProtocol == "-1" {
+		if rule.IPProtocol == "-1" {
 			proto = "all"
 			portRange = ""
 		}
 
-		if rule.IpProtocol == "icmp" || rule.IpProtocol == "icmpv6" {
+		if rule.IPProtocol == "icmp" || rule.IPProtocol == "icmpv6" {
 			if rule.FromPort == -1 || rule.ToPort == -1 {
 				portRange = "all"
 			}
@@ -395,7 +397,7 @@ func printRules(rules []*SecurityGroupRule, ind int, ingress bool) {
 
 		fmt.Printf(
 			"%s%v%v %v%v %v%v%v ",
-			indent(ind+4),
+			indent(ind+4), //nolint:gomnd // not a magic number, spaces to indent by
 			color.Blue,
 			direction,
 			color.Cyan,
@@ -405,13 +407,15 @@ func printRules(rules []*SecurityGroupRule, ind int, ingress bool) {
 			color.Reset,
 		)
 
-		for _, ipRange := range rule.IpRanges {
+		for _, ipRange := range rule.IPRanges {
 			// There should only be one cidr range per rule, but the api permits more.
 			fmt.Printf("%v ", ipRange.CidrIP)
 		}
-		for _, ipRange := range rule.Ipv6Ranges {
+
+		for _, ipRange := range rule.IPv6Ranges {
 			fmt.Printf("%v ", ipRange.CidrIPV6)
 		}
+
 		fmt.Printf("\n")
 	}
 }
@@ -425,8 +429,8 @@ func printSecurityGroup(sg *SecurityGroup, ind int) {
 		color.Reset,
 		sg.GroupName,
 	)
-	printRules(sg.IpPermissions, ind, true)
-	printRules(sg.IpPermissionsEgress, ind, false)
+	printRules(sg.IPPermissions, ind, true)
+	printRules(sg.IPPermissionsEgress, ind, false)
 }
 
 func printVPCs(vpcs []*VPCSorted) {

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func populateVPC(region string) (map[string]*VPC, error) {
 	data := RecievedData{}
 	vpcs := make(map[string]*VPC)
 
-	data.wg.Add(15) //nolint:gomnd // Wait groups increase when requests increase
+	data.wg.Add(16) //nolint:gomnd // Wait groups increase when requests increase
 
 	go getIdentity(stsSvc, &data)
 	go getVpcs(svc, &data)
@@ -60,6 +60,7 @@ func populateVPC(region string) (map[string]*VPC, error) {
 	go getTransitGatewayVpcAttachments(svc, &data)
 	go getVpcPeeringConnections(svc, &data)
 	go getNetworkInterfaces(svc, &data)
+	go getSecurityGroups(svc, &data)
 	go getVpcEndpoints(svc, &data)
 
 	data.wg.Wait()
@@ -83,6 +84,7 @@ func populateVPC(region string) (map[string]*VPC, error) {
 	mapVpcPeeringConnections(vpcs, data.PeeringConnections)
 	mapVpcEndpoints(vpcs, data.VPCEndpoints)
 	mapNetworkInterfaces(vpcs, data.NetworkInterfaces)
+	mapSecurityGroups(vpcs, data.SecurityGroups)
 
 	return vpcs, nil
 }

--- a/requests.go
+++ b/requests.go
@@ -273,6 +273,28 @@ func getNetworkInterfaces(svc *ec2.EC2, data *RecievedData) {
 	data.NetworkInterfaces = ifaces
 }
 
+func getSecurityGroups(svc *ec2.EC2, data *RecievedData) {
+	defer data.wg.Done()
+
+	sgs := []*ec2.SecurityGroup{}
+
+	err := svc.DescribeSecurityGroupsPages(
+		&ec2.DescribeSecurityGroupsInput{},
+		func(page *ec2.DescribeSecurityGroupsOutput, lastPage bool) bool {
+			sgs = append(sgs, page.SecurityGroups...)
+			return !lastPage
+		},
+	)
+
+	if err != nil {
+		data.mu.Lock()
+		data.Error = err
+		data.mu.Unlock()
+	}
+
+	data.SecurityGroups = sgs
+}
+
 func getVpcEndpoints(svc *ec2.EC2, data *RecievedData) {
 	defer data.wg.Done()
 

--- a/sorting.go
+++ b/sorting.go
@@ -214,9 +214,9 @@ func sortInstance(instance *Instance) *InstanceSorted {
 
 	sort.Strings(interfaceKeys)
 
-	interfacesSorted := []*NetworkInterface{}
+	interfacesSorted := []*NetworkInterfaceSorted{}
 	for _, interfaceID := range interfaceKeys {
-		interfacesSorted = append(interfacesSorted, instance.Interfaces[interfaceID])
+		interfacesSorted = append(interfacesSorted, sortNetworkInterface(instance.Interfaces[interfaceID]))
 	}
 
 	return &InstanceSorted{
@@ -234,13 +234,53 @@ func sortInterfaceEndpoint(endpoint *InterfaceEndpoint) *InterfaceEndpointSorted
 
 	sort.Strings(ifaceKeys)
 
-	interfacesSorted := []*NetworkInterface{}
+	interfacesSorted := []*NetworkInterfaceSorted{}
 	for _, interfaceID := range ifaceKeys {
-		interfacesSorted = append(interfacesSorted, endpoint.Interfaces[interfaceID])
+		interfacesSorted = append(interfacesSorted, sortNetworkInterface(endpoint.Interfaces[interfaceID]))
 	}
 
 	return &InterfaceEndpointSorted{
 		InterfaceEndpointData: endpoint.InterfaceEndpointData,
 		Interfaces:            interfacesSorted,
 	}
+}
+
+func sortNetworkInterface(iface *NetworkInterface) *NetworkInterfaceSorted {
+	groupKeys := []string{}
+	for k := range iface.Groups {
+		groupKeys = append(groupKeys, k)
+	}
+
+	sort.Strings(groupKeys)
+
+	groupsSorted := []*SecurityGroup{}
+	for _, groupID := range groupKeys {
+		groupsSorted = append(groupsSorted, iface.Groups[groupID])
+	}
+
+	return &NetworkInterfaceSorted{
+		NetworkInterfaceData: iface.NetworkInterfaceData,
+		Groups:               groupsSorted,
+	}
+}
+
+func sortNatGateway(ng *NatGateway) *NatGatewaySorted {
+
+	ifaceKeys := []string{}
+	for k := range ng.Interfaces {
+		ifaceKeys = append(ifaceKeys, k)
+	}
+
+	sort.Strings(ifaceKeys)
+
+	ifaceSorted := []*NetworkInterfaceSorted{}
+	for _, ifaceID := range ifaceKeys {
+		ifaceSorted = append(ifaceSorted, sortNetworkInterface(ng.Interfaces[ifaceID]))
+	}
+
+	return &NatGatewaySorted{
+		NatGatewayData: ng.NatGatewayData,
+		Interfaces:     ifaceSorted,
+	}
+
 }

--- a/sorting.go
+++ b/sorting.go
@@ -265,7 +265,6 @@ func sortNetworkInterface(iface *NetworkInterface) *NetworkInterfaceSorted {
 }
 
 func sortNatGateway(ng *NatGateway) *NatGatewaySorted {
-
 	ifaceKeys := []string{}
 	for k := range ng.Interfaces {
 		ifaceKeys = append(ifaceKeys, k)
@@ -282,5 +281,4 @@ func sortNatGateway(ng *NatGateway) *NatGatewaySorted {
 		NatGatewayData: ng.NatGatewayData,
 		Interfaces:     ifaceSorted,
 	}
-
 }


### PR DESCRIPTION
The following PR will add security group reporting to the verbose output of lsvpc. This will report on instance ENIs, normal ENIs, Interface endpoints, and NatGateways (if they have security groups).

The reporting format currently looks like the following:
![Screenshot_20230112_142723](https://user-images.githubusercontent.com/74213215/212162584-081edbdf-84e5-4729-a576-af5649324c9c.png)
